### PR TITLE
Refactor: more consistent use of "worker" and "remote" names

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -514,9 +514,6 @@ def request(channel, method, properties, body):
         params,
     )
 
-    current_region = os.environ.get("REGION")
-    systemd_logging_handler._extra["ADT_REGION"] = current_region
-
     # build autopkgtest command line
     work_dir = tempfile.mkdtemp(prefix="autopkgtest-work.")
 

--- a/charms/autopkgtest-dispatcher-operator/app/units/autopkgtest-worker@.service.j2
+++ b/charms/autopkgtest-dispatcher-operator/app/units/autopkgtest-worker@.service.j2
@@ -11,10 +11,9 @@ TimeoutStartSec=5min
 EnvironmentFile=-/etc/environment.d/proxy.conf
 EnvironmentFile={{ conf_directory }}/rabbitmq.cred
 EnvironmentFile={{ conf_directory }}/swift.cred
-ExecStart=/bin/sh -ec 'REGION="%i"; REGION="$${REGION%-*}"; \
-    CONF="{{ conf_directory }}/worker.conf"; \
-    LXD_ARCH=$${REGION#*-}; \
-    exec env REGION=$${REGION} /usr/local/bin/worker --config $$CONF -v LXD_ARCH=$$LXD_ARCH -v LXD_REMOTE=$$REGION -a $$LXD_ARCH'
+ExecStart=/bin/sh -ec '\
+    REMOTE="%i"; REMOTE="$${REMOTE%-*}"; CONF="{{ conf_directory }}/worker.conf"; LXD_ARCH=$${REMOTE#*-}; \
+    exec /usr/local/bin/worker --config $$CONF -v LXD_ARCH=$$LXD_ARCH -v LXD_REMOTE=$$REMOTE -a $$LXD_ARCH'
 ExecReload=/bin/kill -HUP $MAINPID
 SuccessExitStatus=0 99 SIGTERM SIGHUP
 # RestartSec=5min

--- a/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
+++ b/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-autopkgtest-dispatcher
 type: charm
-summary: A charm that deploys an autopkgtest queue dispatcher, to run tests on available workers
-description: A charm that deploys an autopkgtest queue dispatcher, to run tests on available workers
+summary: A charm that deploys an autopkgtest queue dispatcher
+description: A charm that deploys an autopkgtest queue dispatcher
 links:
   issues:
     - https://github.com/canonical/ubuntu-autopkgtest-operators/issues
@@ -30,19 +30,19 @@ parts:
 
 actions:
   reconfigure:
-    description: Reconfigure workers with current distro-info-data
-  add-worker:
-    description: Add a worker to run tests on.
+    description: Reconfigure workers taking into account current distro-info-data.
+  add-remote:
+    description: Add a remote to run tests on.
     params:
       arch:
         type: string
-        description: Architecture of the worker.
+        description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
       token:
         type: string
         description: LXD client token to connect to a remote.
-  set-unit-count:
-    description: Set number of units on a worker.
+  set-worker-count:
+    description: Set number of workers for a given architecture.
     params:
       arch:
         type: string
@@ -50,27 +50,27 @@ actions:
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
       count:
         type: integer
-        description: Number of units.
+        description: Number of workers.
         min: 0
   show-target-config:
     description: Show target config for worker units.
-  create-worker-units:
-    description: Create worker units for target config.
+  reconcile-worker-units:
+    description: Enable/disable worker units according to target config.
 
 config:
   options:
     # charm options
     autopkgtest-git-branch:
       type: string
-      description: salsa.debian.org/ubuntu-ci-team/autopkgtest branch to clone
+      description: salsa.debian.org/ubuntu-ci-team/autopkgtest branch to clone.
       default: ubuntu/staging
     default-worker-count:
       type: int
-      description: Default number of workers to create for a cluster.
+      description: Default number of workers to create for each remote.
       default: 10
     extra-releases:
       type: string
-      description: Space-separated of unsupported release to run tests for
+      description: Space-separated of unsupported release to run tests for.
       default: trusty
 
     # swift

--- a/charms/autopkgtest-dispatcher-operator/src/action_types.py
+++ b/charms/autopkgtest-dispatcher-operator/src/action_types.py
@@ -14,11 +14,13 @@ class SupportedArches(enum.Enum):
     RISCV64 = "riscv64"
 
 
-class AddWorkerAction(pydantic.BaseModel):
-    arch: SupportedArches = pydantic.Field(description="Architecture of the worker.")
-    token: str = pydantic.Field(description="LXD client token to connect to a remote.")
+class AddRemoteAction(pydantic.BaseModel):
+    arch: SupportedArches = pydantic.Field(description="Architecture of the remote.")
+    token: str = pydantic.Field(
+        description="LXD client token to connect to the remote."
+    )
 
 
-class SetUnitCountAction(pydantic.BaseModel):
-    arch: SupportedArches = pydantic.Field(description="Architecture to set units for.")
+class SetWorkerCountAction(pydantic.BaseModel):
+    arch: SupportedArches = pydantic.Field(description="Architecture to configure.")
     count: int = pydantic.Field(10)

--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -244,9 +244,9 @@ def configure(extra_releases, swift_creds, amqp_hostname, amqp_username, amqp_pa
     write_rabbitmq_creds(amqp_hostname, amqp_username, amqp_password)
 
 
-def add_worker(arch: str, token: str):
-    run_as_user(f"lxc remote add worker-{arch} {token}")
+def add_remote(arch: str, token: str):
+    run_as_user(f"lxc remote add remote-{arch} {token}")
 
 
-def create_worker_units(worker_config: dict[str, int]):
-    systemd_helper.set_up_systemd_units(worker_config)
+def reconcile_worker_units(worker_config: dict[str, int]):
+    systemd_helper.reconcile_systemd_worker_units(worker_config)

--- a/charms/autopkgtest-dispatcher-operator/src/systemd_helper.py
+++ b/charms/autopkgtest-dispatcher-operator/src/systemd_helper.py
@@ -1,72 +1,70 @@
 import subprocess
-from collections import defaultdict
+import time
+from collections import Counter
 
 import charms.operator_libs_linux.v1.systemd as systemd
 
 
 class SystemdHelper:
-    def get_autopkgtest_unit_names(self, arch, ns):
-        """Return autopkgtest worker unit filenames for given arch and numbers."""
-        return [f"autopkgtest@worker-{arch}-{n}.service" for n in ns]
+    def generate_worker_unit_names(self, arch, ns):
+        """Return autopkgtest worker unit names for given arch and numbers."""
+        return [f"autopkgtest-worker@remote-{arch}-{n}.service" for n in ns]
 
-    def list_units_by_pattern(self, pattern):
+    def count_worker_units(self):
+        """Count number of worker units per architecture."""
         proc = subprocess.run(
-            ["systemctl", "list-units", f"{pattern}"],
+            [
+                "systemctl",
+                "list-units",
+                "--plain",
+                "--no-legend",
+                "--no-pager",
+                "--type=service",
+                "autopkgtest-worker@remote-*.service",
+            ],
             capture_output=True,
             text=True,
             check=True,
         )
 
-        # have to mangle the systemctl output manually here
-        units = []
-        for line in proc.stdout.splitlines():
-            if "service" not in line or "masked" in line:
-                continue
-            units.append(line.split(" ")[2])
+        worker_count = Counter(
+            line.split()[0].split("@", 1)[1].removesuffix(".service").split("-")[1]
+            for line in proc.stdout.splitlines()
+        )
 
-        return units
+        return worker_count
 
-    def get_autopkgtest_units(self):
-        """Return names for all autopkgtest services in a dict with keys lxd_worker[arch][n]."""
-        lxd_worker_names = defaultdict(lambda: defaultdict(dict))
-
-        lxd_workers = self.list_units_by_pattern("autopkgtest@*")
-
-        for name in lxd_workers:
-            # worker unit names are autopkgtest@cluster-{arch}-{n}.service
-            name_parts = name.split("-")
-            lxd_worker_names[name_parts[1]][name_parts[2]] = name
-
-        return lxd_worker_names
-
-    def set_up_systemd_units(self, target_config):
-        """Enable requested units and remove unneeded ones.
+    def reconcile_systemd_worker_units(self, target_config):
+        """Enable requested units and disable unneeded ones.
 
         target_config is a dict which maps arches to number of workers.
         """
-        lxd_worker_names = self.get_autopkgtest_units()
+        worker_count = self.count_worker_units()
 
         for arch in target_config:
-            n_units = len(lxd_worker_names[arch])
+            n_units = worker_count[arch]
             target_units = target_config[arch]
 
-            print(f"Got {target_units} units for {arch}")
+            print(f"Target {arch} units: {target_units}, already existing: {n_units}")
 
             if n_units < target_units:
-                unit_names = self.get_autopkgtest_unit_names(
+                unit_names = self.generate_worker_unit_names(
                     arch, range(n_units + 1, target_units + 1)
                 )
-                systemd.service_enable("--now", *unit_names)
+                chunk = 10
+                for i in range(0, len(unit_names), chunk):
+                    if i > 0:
+                        # don't drown amqp with connection requests
+                        time.sleep(1)
+                    units_slice = unit_names[i : i + chunk]
+                    print(f"Activating units {units_slice}")
+                    systemd.service_enable("--now", *units_slice)
+
             elif target_units < n_units:
-                unit_names = self.get_autopkgtest_unit_names(
+                print("Deleting extra units")
+                unit_names = self.generate_worker_unit_names(
                     arch, range(target_units + 1, n_units + 1)
                 )
+                # TODO: graceful shutdown of worker units
                 systemd.service_disable("--now", *unit_names)
-
-    def reload_worker_units(self):
-        (lxd_worker_object_paths, _) = self.get_autopkgtest_units()
-
-        for arch in lxd_worker_object_paths:
-            for unit in lxd_worker_object_paths[arch]:
-                unit_name = lxd_worker_object_paths[arch][unit]
-                systemd.reload_unit(unit_name, restart_on_failure=True)
+                systemd._systemctl("reset-failed", *unit_names)

--- a/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
+++ b/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
@@ -9,7 +9,7 @@ EOF
 
 export RELEASE
 
-remote="worker-$arch"
+remote="remote-$arch"
 imgremote="ubuntu-daily"
 base=$RELEASE
 
@@ -51,7 +51,7 @@ set -- "$@" --remote "$remote" "ubuntu-daily:$base/$arch"
 # If RUNTIME_DIRECTORY is set, which normally happens when this script
 # is started from the systemd service, then limit to one image build
 # per architecture (remote).
-if [ -n "${RUNTIME_DIRECTORY-}" ]; then
+if [ -d "${RUNTIME_DIRECTORY-}" ]; then
     set -- flock --verbose "$RUNTIME_DIRECTORY/$arch.lock" "$@"
 fi
 

--- a/charms/autopkgtest-janitor-operator/app/bin/cleanup-lxd
+++ b/charms/autopkgtest-janitor-operator/app/bin/cleanup-lxd
@@ -18,7 +18,7 @@ def main():
 
     now = datetime.datetime.now(datetime.UTC)
     remotes = json.loads(subprocess.check_output(["lxc", "remote", "list", "-fjson"]))
-    remotes = [r for r in remotes if r.startswith("worker-")]
+    remotes = [r for r in remotes if r.startswith("remote-")]
 
     errors = False
     for remote in remotes:
@@ -66,7 +66,7 @@ def main():
 
     if errors:
         print(
-            "Errors encountered during cleanup, see messagesa above",
+            "Errors encountered during cleanup, see messages above",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/charms/autopkgtest-janitor-operator/app/units/autopkgtest-build-image@.service.j2
+++ b/charms/autopkgtest-janitor-operator/app/units/autopkgtest-build-image@.service.j2
@@ -12,4 +12,4 @@ Environment="PATH={{ autopkgtest_location }}/tools:/usr/local/sbin:/usr/local/bi
 Environment="MIRROR={{ mirror }}"
 RuntimeDirectory=%p
 RuntimeDirectoryPreserve=yes
-ExecStart=build-image-on-worker %i
+ExecStart=build-image-on-remote %i

--- a/charms/autopkgtest-janitor-operator/charmcraft.yaml
+++ b/charms/autopkgtest-janitor-operator/charmcraft.yaml
@@ -1,7 +1,7 @@
 name: ubuntu-autopkgtest-janitor
 type: charm
-summary: A charm for performing maintenance for autopkgtest workers.
-description: A charm for performing maintenance for autopkgtest workers.
+summary: A charm for performing maintenance for the autopkgtest infrastructure
+description: A charm for performing maintenance for the autopkgtest infrastructure.
 links:
   issues:
     - https://github.com/canonical/ubuntu-autopkgtest-operators/issues
@@ -29,22 +29,22 @@ parts:
       - units/*
 
 actions:
-  add-worker:
-    description: Add worker to run maintenance tasks on.
+  add-remote:
+    description: Add remote to run maintenance tasks on.
     params:
       arch:
         type: string
-        description: Architecture of the worker.
+        description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
       token:
         type: string
         description: LXD client token to connect to a remote.
-  remove-worker:
-    description: Remove a worker from the janitor.
+  remove-remote:
+    description: Remove a remote from the janitor.
     params:
       arch:
         type: string
-        description: Architecture of the worker.
+        description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
   rebuild-all-images:
     description: Trigger rebuild of all the images

--- a/charms/autopkgtest-janitor-operator/src/action_types.py
+++ b/charms/autopkgtest-janitor-operator/src/action_types.py
@@ -1,10 +1,12 @@
 import pydantic
 
 
-class AddWorkerAction(pydantic.BaseModel):
-    arch: str = pydantic.Field(description="Architecture of the worker.")
-    token: str = pydantic.Field(description="LXD client token to connect to a remote.")
+class AddRemoteAction(pydantic.BaseModel):
+    arch: str = pydantic.Field(description="Architecture of the remote.")
+    token: str = pydantic.Field(
+        description="LXD client token to connect to the remote."
+    )
 
 
-class RemoveWorkerAction(pydantic.BaseModel):
-    arch: str = pydantic.Field(description="Architecture of the worker.")
+class RemoveRemoteAction(pydantic.BaseModel):
+    arch: str = pydantic.Field(description="Architecture of the remote.")


### PR DESCRIPTION
A "remote" is an LXD remote that tests will run on. These remotes are called "remote-ARCH". There is one per architecture.

A worker is a service (systemd service unit, or running instance of the worker script) that pops jobs from the queues and runs them on the remotes.

On top of the refactor there are some bug fixes and some cosmetic changes.