### PR TITLE
Website searchbox

### DIFF
--- a/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
@@ -24,7 +24,7 @@
           <div class="panel-body">
             <p>
               You can navigate to {{base_url}}packages/<i>packagename</i> to get
-              results for a particular package.
+              results for a particular package. Or, you can search from the navbar.
             </p>
           </div>
         </div>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-layout.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-layout.html
@@ -1,3 +1,4 @@
+{% import "macros.html" as macros %}
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-layout.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-layout.html
@@ -48,6 +48,9 @@
               <li>
                 <a href="https://wiki.ubuntu.com/ProposedMigration#autopkgtests">Documentation</a>
               </li>
+            </ul>
+            <ul class="nav navbar-nav navbar-right">
+              {{ macros.searchbox() }}
               {% if not session.get("nickname") %}
                 <li>
                   <a href="{{base_url}}request.cgi?/login">Login</a>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-log.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-log.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h2>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-package.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-package.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h2>{{package}}</h2>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-ppa.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-ppa.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h2>Test runs for {{ ppa_name }}</h2>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-recent.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-recent.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% macro display_test_info(results) -%}
   <table class="table">

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-results.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-results.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h2>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-run.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-run.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h2>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-running.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-running.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% block content %}
   <h1 class="page-header">Running and queued tests</h1>

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-user-ppas.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-user-ppas.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% macro display_ppa_releases(releases) -%}
   [

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-user.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-user.html
@@ -1,5 +1,4 @@
 {% extends "browse-layout.html" %}
-{% import "macros.html" as macros %}
 
 {% macro display_user_test_info(user_results) -%}
   <table class="table">

--- a/charms/autopkgtest-website-operator/app/www/templates/macros.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/macros.html
@@ -172,3 +172,17 @@
     Oops! Looks like this package has no previous results. The package itself may not exist - you can check by clicking the Launchpad icon.
   </p>
 {%- endmacro %}
+
+{% macro searchbox() -%}
+  <form>
+    <input type="text" placeholder="Package name" id="package-search" />
+    <button onclick="searchPackage();">Submit</button>
+  </form>
+
+  <script>
+    function searchPackage() {
+      var package = document.getElementById("package-search").value;
+      window.location = window.location.origin + "/packages/" + package;
+    }
+  </script>
+{% endmacro %}


### PR DESCRIPTION
Add a very basic searchbox to the navbar to go to a particular package and refactor macros importing while I'm at it. The searchbox is essentially just a wrapper around going to the `/packages/<package>` URL directly. Implementing typeahead would be a massive improvement here but the performance costs are worth discussion.