### PR TITLE
All charms: early inject proxy variables in the environment

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -154,12 +154,6 @@ def install(autopkgtest_branch, releases):
                 )
             )
 
-        # changed environment variables don't get picked up by this file
-        # so set them explicitly
-        os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
-        os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
-        os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
-
     logger.info(f"configuring unprivileged user {USER!r}")
 
     # enable-linger so that systemd does not clean the user session

--- a/charms/autopkgtest-dispatcher-operator/src/charm.py
+++ b/charms/autopkgtest-dispatcher-operator/src/charm.py
@@ -2,6 +2,8 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
+
 import action_types
 import autopkgtest_dispatcher
 import config_types
@@ -196,4 +198,9 @@ class AutopkgtestDispatcherCharm(ops.CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
+    # Inject proxy variables into the environment
+    os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
+    os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
+    os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
+
     ops.main(AutopkgtestDispatcherCharm)

--- a/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
+++ b/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
@@ -151,12 +151,6 @@ def enable_image_builders(arch, releases):
         systemd.service_start(*services)
 
 
-def ensure_proxy():
-    os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
-    os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
-    os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
-
-
 def configure_unprivileged_user():
     logger.info(f"configuring unprivileged user {USER!r}")
 
@@ -289,10 +283,6 @@ def install(autopkgtest_branch):
                 )
             )
 
-        # changed environment variables don't get picked up by this file
-        # so set them explicitly
-        ensure_proxy()
-
     logger.info("updating package index")
     apt.update()
 
@@ -343,7 +333,6 @@ def configure(
     amqp_username,
     amqp_password,
 ):
-    ensure_proxy()
     configure_unprivileged_user()
     update_distro_info_data()
     update_autopkgtest(autopkgtest_branch)

--- a/charms/autopkgtest-janitor-operator/src/charm.py
+++ b/charms/autopkgtest-janitor-operator/src/charm.py
@@ -2,6 +2,8 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details
 
+import os
+
 import action_types
 import autopkgtest_janitor
 import config_types
@@ -153,4 +155,9 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
+    # Inject proxy variables into the environment
+    os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
+    os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
+    os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
+
     ops.main(AutopkgtestJanitorCharm)

--- a/charms/autopkgtest-website-operator/src/autopkgtest_website.py
+++ b/charms/autopkgtest-website-operator/src/autopkgtest_website.py
@@ -70,12 +70,6 @@ def install() -> None:
                 )
             )
 
-        # changed environment variables don't get picked up by this file
-        # so set them explicitly
-        os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
-        os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
-        os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
-
     logger.info("Updating package index")
     apt.update()
 

--- a/charms/autopkgtest-website-operator/src/charm.py
+++ b/charms/autopkgtest-website-operator/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm the application."""
+import os
 
 import autopkgtest_website
 import config_types
@@ -153,4 +153,9 @@ class AutopkgtestWebsiteCharm(ops.CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
+    # Inject proxy variables into the environment
+    os.environ["http_proxy"] = os.getenv("JUJU_CHARM_HTTP_PROXY", "")
+    os.environ["https_proxy"] = os.getenv("JUJU_CHARM_HTTPS_PROXY", "")
+    os.environ["no_proxy"] = os.getenv("JUJU_CHARM_NO_PROXY", "")
+
     ops.main(AutopkgtestWebsiteCharm)


### PR DESCRIPTION
Inject the proxy variables in the environment of the process executing the charm early and unconditionally. This way the variables are always present. This is the closes to having the variables _already_ in the environment, which would be the ideal case.