### PR TITLE
dispatcher: enable auto restart for workers

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/units/autopkgtest-worker@.service.j2
+++ b/charms/autopkgtest-dispatcher-operator/app/units/autopkgtest-worker@.service.j2
@@ -16,10 +16,8 @@ ExecStart=/bin/sh -ec '\
     exec /usr/local/bin/worker --config $$CONF -v LXD_ARCH=$$LXD_ARCH -v LXD_REMOTE=$$REMOTE -a $$LXD_ARCH'
 ExecReload=/bin/kill -HUP $MAINPID
 SuccessExitStatus=0 99 SIGTERM SIGHUP
-# RestartSec=5min
-# Restart=on-failure
-# StartLimitInterval=10m
-# StartLimitBurst=3
+RestartSec=2min
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The worker script has proven stable enough by itself, but we should enable auto-restart to guard against rare rabbitmq failures anyway.