### PR TITLE
website: run-autopkgtest: use more precise timestamp

### DIFF
--- a/charms/autopkgtest-website-operator/app/bin/run-autopkgtest
+++ b/charms/autopkgtest-website-operator/app/bin/run-autopkgtest
@@ -167,7 +167,7 @@ if __name__ == "__main__":
         except KeyError:
             pass
     params["submit-time"] = datetime.strftime(
-        datetime.now().astimezone(UTC), "%Y-%m-%d %H:%M:%S%z"
+        datetime.now().astimezone(UTC), "%Y-%m-%d %H:%M:%S.%f%z"
     )
     params = "\n" + json.dumps(params)
 


### PR DESCRIPTION
Using only seconds in the submit-time timestamp was causing runhash collisions which caused inaccuracies in the running test count, append millis to the timestamp.