### PR TITLE
Drop calling autopkgtest with --env for proxy variables

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -80,12 +80,6 @@ def is_proxy_defined():
 
 def write_worker_config(releases):
     extra_args = []
-    if is_proxy_defined():
-        extra_args = [
-            f"--env http_proxy={os.getenv('JUJU_CHARM_HTTP_PROXY')}",
-            f"--env https_proxy={os.getenv('JUJU_CHARM_HTTPS_PROXY')}",
-            f"--env no_proxy={os.getenv('JUJU_CHARM_NO_PROXY')}",
-        ]
     with open(WORKER_CONFIG_PATH, "w") as file:
         file.write(
             dedent(


### PR DESCRIPTION
Two reasons for this:

(1) Testbed hosts are not entirely homogeneous, so we can't blindly apply the same proxy variables everywhere.

(2) We should offer connectivity transparently using the aproxy subordinate. Most tests with needs-internet expect this.