### PR TITLE
website: seed-new-env: do not modify env field

### DIFF
--- a/charms/autopkgtest-website-operator/app/bin/seed-new-release
+++ b/charms/autopkgtest-website-operator/app/bin/seed-new-release
@@ -39,10 +39,6 @@ def publish_run_results(
     triggers,
     env,
 ):
-    # insert "seeded-run" into the env to prevent
-    # dead swift links from being printed on the website
-    env = " ".join(env.split() + ["seeded-run"])
-
     # create a dummy swift directory
     # autopkgtest-db-writer only cares about the run_id at the end
     # so the rest of the string is unimportant


### PR DESCRIPTION
This was an experiment that we shouldn't keep around, we'll have to find another way to denote test runs which are actually just seeding a new release.