### PR TITLE
worker: use amd64 images for i386

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -703,7 +703,7 @@ def request(channel, method, properties, body):
             big_pkg,
             vm_pkg,
             release,
-            architecture,
+            architecture if architecture != "i386" else "amd64",
         ).split()
 
         if "swiftuser" in params:


### PR DESCRIPTION
This is ugly, and we should handle partial architectures better, especially given that more are coming, but for the moment this is good enough.