### PR TITLE
website: hide pretty-print log link for now

### DIFF
--- a/charms/autopkgtest-website-operator/app/www/templates/browse-run.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-run.html
@@ -65,8 +65,11 @@
       <th></th>
       <td>
         {% if test_results["result"] not in ["running", "queued"] %}
+          <!-- Reinstantiate once all logs all logs are copied to new swift
           <a href="{{ url_for('display_run_summary', release=release, arch=arch, package=package, run_id=test_results['run_id']) }}/log">log</a>
           (<a href="{{ test_results['url'] }}/log.gz">raw</a>) &emsp;
+          -->
+          <a href="{{ test_results['url'] }}/log.gz">log</a> &emsp;
           <a href="{{ test_results['url'] }}/artifacts.tar.gz">artifacts</a> &emsp;
 
         {% endif %}

--- a/charms/autopkgtest-website-operator/app/www/templates/macros.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/macros.html
@@ -122,8 +122,11 @@
   </td>
   <td class="nowrap">
     {% if run_id %}
+      <!-- Reinstantiate once all logs all logs are copied to new swift
       <a href="{{ url_for('display_run_summary', release=release, arch=arch, package=package, run_id=run_id) }}/log">log</a>
       (<a href="{{ url }}/log.gz">raw</a>)&emsp;<a href="{{ url }}/artifacts.tar.gz">artifacts</a>
+      -->
+      <a href="{{ url }}/log.gz">log</a>&emsp;<a href="{{ url }}/artifacts.tar.gz">artifacts</a>
     {% endif %}
   </td>
   <td class="nowrap">


### PR DESCRIPTION
Those links will be broken for pre-ps7-migration logs until we copy over all the logs. Let's hide the link for now to not confuse users.