### PR TITLE
Revert "Drop calling autopkgtest with --env for proxy variables"

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -80,6 +80,12 @@ def is_proxy_defined():
 
 def write_worker_config(releases):
     extra_args = []
+    if is_proxy_defined():
+        extra_args = [
+            f"--env http_proxy={os.getenv('JUJU_CHARM_HTTP_PROXY')}",
+            f"--env https_proxy={os.getenv('JUJU_CHARM_HTTPS_PROXY')}",
+            f"--env no_proxy={os.getenv('JUJU_CHARM_NO_PROXY')}",
+        ]
     with open(WORKER_CONFIG_PATH, "w") as file:
         file.write(
             dedent(


### PR DESCRIPTION
This reverts commit dfe89cce067871c56786553fcdcd90238ed45529.

Rationale:

1. testbeds are homogeneous now (all on ps7)
1. aproxy does not seems to be capable of proxying traffic originating from the lxd bridge, and appears to break lxd clusters.