### PR TITLE
website: remove delete action from requests

### DIFF
--- a/charms/autopkgtest-website-operator/app/www/request/app.py
+++ b/charms/autopkgtest-website-operator/app/www/request/app.py
@@ -277,17 +277,6 @@ def index_root():
         except WebControlException as e:
             return invalid(e, e.exit_code())
 
-        if params.get("delete"):
-            del params["delete"]
-            if params.get("ppas"):
-                count = s.unsend_amqp_request(context="ppa", **params)
-            else:
-                count = s.unsend_amqp_request(**params)
-
-            return HTML.format(LOGOUT + f"<p>Deleted {count} requests</p>").format(
-                **ChainMap(session, params)
-            )
-
         if params.get("ppas"):
             s.send_amqp_request(context="ppa", **params)
         else:

--- a/charms/autopkgtest-website-operator/app/www/request/submit.py
+++ b/charms/autopkgtest-website-operator/app/www/request/submit.py
@@ -83,12 +83,6 @@ class Submit:
         can_upload_any_trigger = False
 
         try:
-            if kwargs["delete"] != "1":
-                raise ValueError("Invalid delete value")
-            del kwargs["delete"]
-        except KeyError:
-            pass
-        try:
             if kwargs["all-proposed"] != "1":
                 raise ValueError("Invalid all-proposed value")
             del kwargs["all-proposed"]
@@ -235,31 +229,6 @@ class Submit:
             raise BadRequest(
                 "Unsupported arguments: {}".format(" ".join(unsupported_keys))
             )
-
-    def unsend_amqp_request(self, release, arch, package, context=None, **params):
-        """Remove an autopkgtest AMQP request."""
-        if context:
-            queue = f"debci-{context}-{release}-{arch}"
-        else:
-            queue = f"debci-{release}-{arch}"
-
-        count = 0
-
-        with amqp_connect() as amqp_con:
-            with amqp_con.channel() as ch:
-                while True:
-                    method, properties, body = ch.basic_get(queue)
-                    if body is None:
-                        break
-                    body = body.decode()
-                    this_package, this_params = body.split(None, 1)
-                    this_params = json.loads(this_params)
-                    del this_params["submit-time"]
-
-                    if this_package == package and this_params == params:
-                        ch.basic_ack(method.delivery_tag)
-                        count += 1
-        return count
 
     def send_amqp_request(self, release, arch, package, context=None, **params):
         """Send autopkgtest AMQP request."""


### PR DESCRIPTION
This action was impossible to reach due to checks that have been added since. I also don't love how easy this makes it to unqueue tests queued by others.

However, it would be useful to have some method of queue management, so this might end up being readded in some capacity down the line.