### PR TITLE
website: add alerts

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/autopkgtest-cloud.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/autopkgtest-cloud.conf.j2
@@ -8,6 +8,7 @@ ppa_containers_cache_dir={{ data }}
 archive_url=http://archive.ubuntu.com/ubuntu
 amqp_queue_cache={{ data }}/queued.json
 running_cache={{ data }}/running.json
+alert={{ data }}/alert.txt
 allowed_requestors=autopkgtest-requestors
 
 [amqp]

--- a/charms/autopkgtest-website-operator/app/www/browse.cgi
+++ b/charms/autopkgtest-website-operator/app/www/browse.cgi
@@ -70,6 +70,18 @@ def init_config():
     CONFIG["amqp_queue_cache"] = Path(cp["web"]["amqp_queue_cache"])
     CONFIG["running_cache"] = Path(cp["web"]["running_cache"])
     CONFIG["database"] = Path(cp["web"]["database_public"])
+    CONFIG["alert"] = Path(cp["web"]["alert"])
+
+
+def get_alert():
+    try:
+        with open(CONFIG["alert"]) as f:
+            # alerts are in the format level:message
+            raw_alert = f.read()
+            level, message = raw_alert.split(":")
+            return {"level": level, "message": message}
+    except (FileNotFoundError, ValueError):
+        return None
 
 
 def get_test_id(release, arch, src):
@@ -351,6 +363,8 @@ def get_running_for_user(user: str):
 def index_root():
     flask.session.permanent = True
 
+    alert = get_alert()
+
     recent = []
     for row in db_con.execute(
         "SELECT exitcode, package, release, arch, triggers, run_id "
@@ -366,6 +380,7 @@ def index_root():
     return render(
         "browse-home.html",
         recent_runs=recent,
+        alert=alert,
     )
 
 

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
@@ -2,7 +2,7 @@
 {% block content %}
   <div class="container">
     <div class="row">
-
+      {% if alert %}<div class="alert alert-{{ alert.level }}">{{ alert.message }}</div>{% endif %}
       <div class="col-md-4">
         <div class="panel panel-default">
           <div class="panel-heading">Recent test runs</div>
@@ -18,7 +18,6 @@
           </div>
         </div>
       </div>
-
       <div class="col-md-4">
         <div class="panel panel-default">
           <div class="panel-heading">Test Results</div>

--- a/charms/autopkgtest-website-operator/charmcraft.yaml
+++ b/charms/autopkgtest-website-operator/charmcraft.yaml
@@ -27,6 +27,20 @@ charm-libs:
   - lib: traefik_k8s.ingress
     version: "2"
 
+actions:
+  set-alert:
+    description: Display an alert on the autopkgtest homepage.
+    params:
+      level:
+        type: string
+        description: Level of the alert (info, warning, danger).
+        enum: [info, warning, danger]
+      message:
+        type: string
+        description: Alert message to display.
+  remove-alert:
+    description: Remove displayed alert.
+
 config:
   options:
     hostname:

--- a/charms/autopkgtest-website-operator/src/action_types.py
+++ b/charms/autopkgtest-website-operator/src/action_types.py
@@ -1,0 +1,16 @@
+import enum
+
+import pydantic
+
+
+class AlertLevels(enum.Enum):
+    INFO = "info"
+    WARNING = "warning"
+    DANGER = "danger"
+
+
+class SetAlertAction(pydantic.BaseModel):
+    level: AlertLevels = pydantic.Field(
+        description="Level of the alert. (info, warning, danger)"
+    )
+    message: str = pydantic.Field(description="The alert message to display.")

--- a/charms/autopkgtest-website-operator/src/autopkgtest_website.py
+++ b/charms/autopkgtest-website-operator/src/autopkgtest_website.py
@@ -54,6 +54,16 @@ PACKAGES = [
 ]
 
 
+def set_alert(level: str, message: str):
+    with open(DATA_DIR / "alert.txt", "w") as f:
+        f.write(f"{level.lower()}:{message}")
+    shutil.chown(DATA_DIR / "alert.txt", user=USER, group=USER)
+
+
+def remove_alert():
+    (DATA_DIR / "alert.txt").unlink(missing_ok=True)
+
+
 def install() -> None:
     """Install website."""
     if "JUJU_CHARM_HTTPS_PROXY" in os.environ or "JUJU_CHARM_HTTP_PROXY" in os.environ:

--- a/charms/autopkgtest-website-operator/src/charm.py
+++ b/charms/autopkgtest-website-operator/src/charm.py
@@ -4,6 +4,7 @@
 
 import os
 
+import action_types
 import autopkgtest_website
 import config_types
 import ops
@@ -115,6 +116,13 @@ class AutopkgtestWebsiteCharm(ops.CharmBase):
         autopkgtest_website.start()
         self.unit.open_port("tcp", HTTP_PORT)
         self.unit.status = ops.ActiveStatus()
+
+    def _on_set_alert(self, event: ops.ActionEvent):
+        params = event.load_params(action_types.SetAlertAction, errors="fail")
+        autopkgtest_website.set_alert(params.level, params.message)
+
+    def _on_remove_alert(self, event: ops.ActionEvent):
+        autopkgtest_website.remove_alert()
 
     def _on_amqp_relation_joined(self, event: ops.RelationJoinedEvent):
         self.unit.status = ops.MaintenanceStatus(


### PR DESCRIPTION
Add the capability to the website of displaying alerts, using the bootstrap component. Add actions to the charm for setting or removing these alerts.