### PR TITLE
Add support for multiple remotes per arch

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
+++ b/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
@@ -32,6 +32,10 @@ actions:
         type: string
         description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
+      index:
+        type: integer
+        description: Index of the new remote.
+        min: 1
       token:
         type: string
         description: LXD client token to connect to a remote.
@@ -42,6 +46,10 @@ actions:
         type: string
         description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
+      index:
+        type: integer
+        description: Index of the remote to remove.
+        min: 1
   set-worker-count:
     description: Set number of workers for a given architecture.
     params:

--- a/charms/autopkgtest-dispatcher-operator/src/action_types.py
+++ b/charms/autopkgtest-dispatcher-operator/src/action_types.py
@@ -16,6 +16,7 @@ class SupportedArches(enum.Enum):
 
 class AddRemoteAction(pydantic.BaseModel):
     arch: SupportedArches = pydantic.Field(description="Architecture of the remote.")
+    index: int = pydantic.Field(description="Index of the new remote.")
     token: str = pydantic.Field(
         description="LXD client token to connect to the remote."
     )
@@ -23,6 +24,7 @@ class AddRemoteAction(pydantic.BaseModel):
 
 class RemoveRemoteAction(pydantic.BaseModel):
     arch: SupportedArches = pydantic.Field(description="Architecture of the remote.")
+    index: int = pydantic.Field(description="Index of the remote to remove.")
 
 
 class SetWorkerCountAction(pydantic.BaseModel):

--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -257,13 +257,13 @@ def configure(
     update_autopkgtest(autopkgtest_branch)
 
 
-def add_remote(arch: str, token: str):
-    run_as_user(f"lxc remote add remote-{arch} {token}")
+def add_remote(arch: str, index: int, token: str):
+    run_as_user(f"lxc remote add remote-{arch}-{index} {token}")
 
 
-def remove_remote(arch: str):
+def remove_remote(arch: str, index: int):
     run_as_user(
-        f"lxc remote list --format=csv | {{ ! grep -q '^remote-{arch},'; }} || lxc remote remove remote-{arch}"
+        f"lxc remote list --format=csv | {{ ! grep -q '^remote-{arch}-{index},'; }} || lxc remote remove remote-{arch}-{index}"
     )
 
 

--- a/charms/autopkgtest-dispatcher-operator/src/charm.py
+++ b/charms/autopkgtest-dispatcher-operator/src/charm.py
@@ -77,27 +77,35 @@ class AutopkgtestDispatcherCharm(ops.CharmBase):
         """Handle adding a new remote."""
         params = event.load_params(action_types.AddRemoteAction, errors="fail")
         remote_arch = params.arch.value
+        index = params.index
+        remote_key = f"remote-{remote_arch}-{index}"
 
-        event.log(f"Adding remote for arch {remote_arch}")
+        if remote_key in self._stored.workers:
+            event.fail(f"remote with index {index} already exists for {remote_arch}")
+            return
+
+        event.log(f"Adding remote #{index} for arch {remote_arch}")
         try:
-            autopkgtest_dispatcher.add_remote(remote_arch, params.token)
+            autopkgtest_dispatcher.add_remote(remote_arch, index, params.token)
         except:
-            event.fail(f"Failed to add remote for arch {remote_arch}")
+            event.fail(f"Failed to add remote #{index} for arch {remote_arch}")
             return
         event.log(
             f"New remote defaults to {self.typed_config.default_worker_count} workers"
         )
-        self._stored.workers[remote_arch] = self.typed_config.default_worker_count
-        event.set_results({"result": f"Added remote for {remote_arch}"})
+        self._stored.workers[remote_key] = self.typed_config.default_worker_count
+        event.set_results({"result": f"Added remote #{index} for {remote_arch}"})
 
     def _on_remove_remote(self, event: ops.ActionEvent):
         """Handle removing a remote."""
         params = event.load_params(action_types.RemoveRemoteAction, errors="fail")
         remote_arch = params.arch.value
-        self._stored.workers[remote_arch] = 0
+        index = params.index
+        remote_key = f"remote-{remote_arch}-{index}"
+        self._stored.workers[remote_key] = 0
         autopkgtest_dispatcher.reconcile_worker_units(self._stored.workers)
-        autopkgtest_dispatcher.remove_remote(remote_arch)
-        del self._stored.workers[remote_arch]
+        autopkgtest_dispatcher.remove_remote(remote_arch, index)
+        del self._stored.workers[remote_key]
 
     def _on_set_worker_count(self, event: ops.ActionEvent):
         params = event.load_params(action_types.SetWorkerCountAction, errors="fail")

--- a/charms/autopkgtest-janitor-operator/charmcraft.yaml
+++ b/charms/autopkgtest-janitor-operator/charmcraft.yaml
@@ -32,6 +32,10 @@ actions:
         type: string
         description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
+      index:
+        type: integer
+        description: Index of the new remote.
+        min: 1
       token:
         type: string
         description: LXD client token to connect to a remote.
@@ -42,6 +46,10 @@ actions:
         type: string
         description: Architecture of the remote.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
+      index:
+        type: integer
+        description: Index of the remote to remove.
+        min: 1
   rebuild-all-images:
     description: Trigger rebuild of all the images
 

--- a/charms/autopkgtest-janitor-operator/charmcraft.yaml
+++ b/charms/autopkgtest-janitor-operator/charmcraft.yaml
@@ -59,14 +59,6 @@ config:
       type: string
       description: Ubuntu mirror to use
       default: http://archive.ubuntu.com/ubuntu/
-    max-instances:
-      type: int
-      description: Max number of instances per remote
-      # A sensible default is a bit higher than the dispatcher's
-      # default-worker-count, to allow all workers for a remote
-      # to get a testbed, plus some headroom for image building
-      # and occasional stray instances.
-      default: 15
 
 requires:
   amqp:

--- a/charms/autopkgtest-janitor-operator/src/action_types.py
+++ b/charms/autopkgtest-janitor-operator/src/action_types.py
@@ -3,6 +3,7 @@ import pydantic
 
 class AddRemoteAction(pydantic.BaseModel):
     arch: str = pydantic.Field(description="Architecture of the remote.")
+    index: int = pydantic.Field(description="Index of the new remote.")
     token: str = pydantic.Field(
         description="LXD client token to connect to the remote."
     )
@@ -10,3 +11,4 @@ class AddRemoteAction(pydantic.BaseModel):
 
 class RemoveRemoteAction(pydantic.BaseModel):
     arch: str = pydantic.Field(description="Architecture of the remote.")
+    index: int = pydantic.Field(description="Index of the remote to remove.")

--- a/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
+++ b/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
@@ -76,7 +76,7 @@ def run_as_user(command: str, *, capture_output=False, check=True):
     )
 
 
-def disable_image_builders(arch, releases):
+def disable_image_builders(arch, releases, index="*"):
     """Disable image builders."""
     # We don't try to be smart here hoping to have a good representation
     # of the state of the units. We just query for existing matching units
@@ -84,7 +84,7 @@ def disable_image_builders(arch, releases):
 
     for release in releases:
         # stop all matching units
-        systemd.service_stop(f"autopkgtest-build-image@{arch}-{release}-*.*")
+        systemd.service_stop(f"autopkgtest-build-image@{arch}-{index}-{release}-*.*")
 
         # disable all enabled matching units
 
@@ -97,7 +97,7 @@ def disable_image_builders(arch, releases):
                 "--no-legend",
                 "--no-pager",
                 "--state=enabled",
-                f"autopkgtest-build-image@{arch}-{release}-*.*",
+                f"autopkgtest-build-image@{arch}-{index}-{release}-*.*",
             ],
             text=True,
             capture_output=True,
@@ -112,13 +112,13 @@ def disable_image_builders(arch, releases):
             [
                 "systemctl",
                 "reset-failed",
-                f"autopkgtest-build-image@{arch}-{release}-*.*",
+                f"autopkgtest-build-image@{arch}-{index}-{release}-*.*",
             ],
             stderr=subprocess.DEVNULL,
         )
 
 
-def enable_image_builders(arch, releases):
+def enable_image_builders(arch, index, releases):
     for i, release in enumerate(releases):
         if (
             release in RELEASE_ARCH_RESTRICTIONS
@@ -131,16 +131,22 @@ def enable_image_builders(arch, releases):
         if i > 0:
             time.sleep(3)
 
-        timers = [f"autopkgtest-build-image@{arch}-{release}-container.timer"]
-        services = [f"autopkgtest-build-image@{arch}-{release}-container.service"]
+        timers = [f"autopkgtest-build-image@{arch}-{index}-{release}-container.timer"]
+        services = [
+            f"autopkgtest-build-image@{arch}-{index}-{release}-container.service"
+        ]
         if arch in VM_ARCHITECTURES:
-            timers.append(f"autopkgtest-build-image@{arch}-{release}-vm.timer")
-            services.append(f"autopkgtest-build-image@{arch}-{release}-vm.service")
+            timers.append(f"autopkgtest-build-image@{arch}-{index}-{release}-vm.timer")
+            services.append(
+                f"autopkgtest-build-image@{arch}-{index}-{release}-vm.service"
+            )
 
-        logger.info(f"Enabling periodic image builds for {arch}/{release}")
+        logger.info(
+            f"Enabling periodic image builds for {release} on remote {arch}-{index}"
+        )
         systemd.service_enable("--now", *timers)
 
-        logger.info(f"Starting image builds for {arch}/{release}")
+        logger.info(f"Starting image builds for {release} on remote {arch}-{index}")
         systemd.service_start(*services)
 
 
@@ -334,25 +340,22 @@ def get_remotes():
     )
 
 
-def add_remote(arch: str, token: str, all_releases: list[str], max_instances):
+def add_remote(arch: str, index: int, token: str, all_releases: list[str]):
     """Handle adding a new remote."""
-    remote = f"remote-{arch}"
-
-    if remote in get_remotes():
-        raise Exception(f"LXD remote already configured for {arch}")
+    remote = f"remote-{arch}-{index}"
 
     run_as_user(f"lxc remote add '{remote}' '{token}'")
 
     if remote not in get_remotes():
-        raise Exception(f"LXD not reporting remote for {arch} as expected")
+        raise Exception(f"LXD not reporting remote #{index} for {arch} as expected")
 
-    enable_image_builders(arch, all_releases)
+    enable_image_builders(arch, index, all_releases)
 
 
-def remove_remote(arch: str, all_releases):
+def remove_remote(arch: str, index: int, all_releases):
     """Remove an existing remote."""
-    disable_image_builders(arch, all_releases)
-    run_as_user(f"lxc remote remove 'remote-{arch}'", check=False)
+    disable_image_builders(arch, all_releases, index)
+    run_as_user(f"lxc remote remove 'remote-{arch}-{index}'", check=False)
 
 
 def rebuild_all_images():

--- a/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
+++ b/charms/autopkgtest-janitor-operator/src/autopkgtest_janitor.py
@@ -76,13 +76,6 @@ def run_as_user(command: str, *, capture_output=False, check=True):
     )
 
 
-def set_limits(arch: str, max_instances) -> None:
-    """Set instance limits."""
-    remote = f"remote-{arch}"
-
-    run_as_user(f"lxc project set {remote}:default limits.instances {max_instances}")
-
-
 def disable_image_builders(arch, releases):
     """Disable image builders."""
     # We don't try to be smart here hoping to have a good representation
@@ -261,12 +254,6 @@ def configure_builder_units(arches, stored_releases, target_releases):
             enable_image_builders(arch, new_releases)
 
 
-def set_instance_limits(arches, max_instances):
-    logger.info("setting instance limits")
-    for arch in arches:
-        set_limits(arch, max_instances)
-
-
 def install(autopkgtest_branch):
     """Install janitor."""
     if "JUJU_CHARM_HTTPS_PROXY" in os.environ or "JUJU_CHARM_HTTP_PROXY" in os.environ:
@@ -328,7 +315,6 @@ def configure(
     mirror,
     stored_releases,
     target_releases,
-    max_instances,
     amqp_hostname,
     amqp_username,
     amqp_password,
@@ -340,7 +326,6 @@ def configure(
     write_rabbitmq_creds(amqp_hostname, amqp_username, amqp_password)
     install_systemd_units(mirror)
     configure_builder_units(arches, stored_releases, target_releases)
-    set_instance_limits(arches, max_instances)
 
 
 def get_remotes():
@@ -360,8 +345,6 @@ def add_remote(arch: str, token: str, all_releases: list[str], max_instances):
 
     if remote not in get_remotes():
         raise Exception(f"LXD not reporting remote for {arch} as expected")
-
-    set_limits(arch, max_instances)
 
     enable_image_builders(arch, all_releases)
 

--- a/charms/autopkgtest-janitor-operator/src/charm.py
+++ b/charms/autopkgtest-janitor-operator/src/charm.py
@@ -67,10 +67,16 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
         """Handle adding a new remote."""
         params = event.load_params(action_types.AddRemoteAction, errors="fail")
         arch = params.arch
+        index = params.index
         token = params.token
+        new_remote = f"remote-{arch}-{index}"
+        if new_remote in self._stored.remotes:
+            event.fail(f"remote with index {index} already exists for {arch}")
+            return
         try:
             autopkgtest_janitor.add_remote(
                 arch,
+                index,
                 token,
                 self._stored.releases,
             )
@@ -78,17 +84,19 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
             event.fail(f"failed to add remote: {e}")
             return
 
-        self._stored.remotes.add(arch)
+        self._stored.remotes.add(f"remote-{arch}-{index}")
 
-        event.set_results({"result": f"Added remote for {arch}"})
+        event.set_results({"result": f"Added remote #{index} for {arch}"})
 
     def _on_remove_remote(self, event: ops.ActionEvent):
         """Handle removing a remote."""
         params = event.load_params(action_types.RemoveRemoteAction, errors="fail")
         arch = params.arch
-        autopkgtest_janitor.remove_remote(arch, self._stored.releases)
-        if arch in self._stored.remotes:
-            self._stored.remotes.remove(arch)
+        index = params.index
+        remote = f"remote-{arch}-{index}"
+        autopkgtest_janitor.remove_remote(arch, index, self._stored.releases)
+
+        self._stored.remotes.remove(remote)
 
     def _on_rebuild_all_images(self, event: ops.ActionEvent):
         """Rebuild all images."""

--- a/charms/autopkgtest-janitor-operator/src/charm.py
+++ b/charms/autopkgtest-janitor-operator/src/charm.py
@@ -73,7 +73,6 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
                 arch,
                 token,
                 self._stored.releases,
-                self.typed_config.max_instances,
             )
         except Exception as e:
             event.fail(f"failed to add remote: {e}")
@@ -108,7 +107,6 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
             mirror=self.typed_config.mirror,
             stored_releases=self._stored.releases,
             target_releases=self.typed_config.releases,
-            max_instances=self.typed_config.max_instances,
             amqp_hostname=self._stored.amqp_hostname,
             amqp_username=RABBITMQ_USERNAME,
             amqp_password=self._stored.amqp_password,

--- a/charms/autopkgtest-janitor-operator/src/config_types.py
+++ b/charms/autopkgtest-janitor-operator/src/config_types.py
@@ -13,4 +13,3 @@ class JanitorConfig(pydantic.BaseModel):
     autopkgtest_git_branch: str
     releases: list[str]
     mirror: str
-    max_instances: int


### PR DESCRIPTION
This is an (untested, experimental) change adding support for having more than one remote per arch on both the janitor and dispatcher. There may or may not need to be some changes made to the worker or its service as well.

Also removed the set_instances functionality from the janitor while I was in there. That could be separated out into its own PR if necessary.