### PR TITLE
dispatcher: improve formatting of show-target-config

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/charm.py
+++ b/charms/autopkgtest-dispatcher-operator/src/charm.py
@@ -123,7 +123,10 @@ class AutopkgtestDispatcherCharm(ops.CharmBase):
         )
 
     def _on_show_target_config(self, event: ops.ActionEvent):
-        event.set_results({"results": f"{self._stored.workers}"})
+        workers = self._stored.workers
+        event.set_results(
+            {"results": "\n".join(f"{k}: {workers[k]}" for k in sorted(workers))}
+        )
 
     def _on_reconcile_worker_units(self, event: ops.ActionEvent):
         autopkgtest_dispatcher.reconcile_worker_units(self._stored.workers)


### PR DESCRIPTION
output was otherwise messy to read as a straight json dump. the new output is formatted as:
```
  remote-amd64-24: 3
  remote-amd64-25: 3
  remote-amd64-26: 3
  remote-amd64-27: 3
  remote-amd64-28: 3
  remote-amd64-29: 3
  remote-amd64-30: 3
  remote-amd64-31: 3
  remote-amd64-32: 3
  remote-amd64-33: 3
  remote-amd64-34: 3
  remote-amd64-35: 3
  remote-amd64v3-86: 3
```
and so on.