### PR TITLE
dispatcher: package_size_big: set limits.memory=8GiB

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -104,7 +104,7 @@ def write_worker_config(releases):
                 [virt]
                 args = lxd --delete-existing --name $NAME $VMOPT -r $LXD_REMOTE $LXD_REMOTE:autopkgtest/ubuntu/$RELEASE/$ARCHITECTURE$VMFLAG $PACKAGESIZE
                 package_size_default = -c limits.cpu=2 -c limits.memory=4GiB -d root,size=20GiB
-                package_size_big = -c limits.cpu=4 -c limits.memory=16GiB -d root,size=100GiB
+                package_size_big = -c limits.cpu=4 -c limits.memory=8GiB -d root,size=100GiB
                 """
             )
         )


### PR DESCRIPTION
I think setting it to 16GiB was not intentional; we document 8GiB.