### PR TITLE
website: expand alerts feature

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/autopkgtest-cloud.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/autopkgtest-cloud.conf.j2
@@ -8,7 +8,7 @@ ppa_containers_cache_dir={{ data }}
 archive_url=http://archive.ubuntu.com/ubuntu
 amqp_queue_cache={{ data }}/queued.json
 running_cache={{ data }}/running.json
-alert={{ data }}/alert.txt
+alerts={{ data }}/alerts.json
 allowed_requestors=autopkgtest-requestors
 
 [amqp]

--- a/charms/autopkgtest-website-operator/app/www/browse.cgi
+++ b/charms/autopkgtest-website-operator/app/www/browse.cgi
@@ -70,18 +70,16 @@ def init_config():
     CONFIG["amqp_queue_cache"] = Path(cp["web"]["amqp_queue_cache"])
     CONFIG["running_cache"] = Path(cp["web"]["running_cache"])
     CONFIG["database"] = Path(cp["web"]["database_public"])
-    CONFIG["alert"] = Path(cp["web"]["alert"])
+    CONFIG["alerts"] = Path(cp["web"]["alerts"])
 
 
-def get_alert():
+def get_alerts():
     try:
-        with open(CONFIG["alert"]) as f:
-            # alerts are in the format level:message
-            raw_alert = f.read()
-            level, message = raw_alert.split(":")
-            return {"level": level, "message": message}
-    except (FileNotFoundError, ValueError):
-        return None
+        with open(CONFIG["alerts"]) as f:
+            # alerts are stored as a JSON array
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
 
 
 def get_test_id(release, arch, src):
@@ -367,7 +365,7 @@ def get_running_for_user(user: str):
 def index_root():
     flask.session.permanent = True
 
-    alert = get_alert()
+    alerts = get_alerts()
 
     recent = []
     for row in db_con.execute(
@@ -384,7 +382,7 @@ def index_root():
     return render(
         "browse-home.html",
         recent_runs=recent,
-        alert=alert,
+        alerts=alerts,
     )
 
 

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-home.html
@@ -2,7 +2,11 @@
 {% block content %}
   <div class="container">
     <div class="row">
-      {% if alert %}<div class="alert alert-{{ alert.level }}">{{ alert.message }}</div>{% endif %}
+      {% for alert in alerts %}
+        <div class="alert alert-{{ alert.level }}">
+          <strong>[{{ alert.date }}]</strong> {{ alert.message }}
+        </div>
+      {% endfor %}
       <div class="col-md-4">
         <div class="panel panel-default">
           <div class="panel-heading">Recent test runs</div>

--- a/charms/autopkgtest-website-operator/charmcraft.yaml
+++ b/charms/autopkgtest-website-operator/charmcraft.yaml
@@ -28,7 +28,7 @@ charm-libs:
     version: "2"
 
 actions:
-  set-alert:
+  add-alert:
     description: Display an alert on the autopkgtest homepage.
     params:
       level:
@@ -39,7 +39,15 @@ actions:
         type: string
         description: Alert message to display.
   remove-alert:
-    description: Remove displayed alert.
+    description: Remove the specified alert.
+    params:
+      id:
+        type: integer
+        description: ID of the alert to remove.
+  clear-alerts:
+    description: Remove all displayed alerts.
+  list-alerts:
+    description: List all active alerts.
 
 config:
   options:

--- a/charms/autopkgtest-website-operator/src/action_types.py
+++ b/charms/autopkgtest-website-operator/src/action_types.py
@@ -9,8 +9,12 @@ class AlertLevels(enum.Enum):
     DANGER = "danger"
 
 
-class SetAlertAction(pydantic.BaseModel):
+class AddAlertAction(pydantic.BaseModel):
     level: AlertLevels = pydantic.Field(
         description="Level of the alert. (info, warning, danger)"
     )
     message: str = pydantic.Field(description="The alert message to display.")
+
+
+class RemoveAlertAction(pydantic.BaseModel):
+    alert_id: int = pydantic.Field(description="ID of the alert to remove.")

--- a/charms/autopkgtest-website-operator/src/autopkgtest_website.py
+++ b/charms/autopkgtest-website-operator/src/autopkgtest_website.py
@@ -6,10 +6,12 @@
 The intention is that this module could be used outside the context of a charm.
 """
 
+import json
 import logging
 import os
 import shutil
 import subprocess
+from datetime import date
 from pathlib import Path
 from textwrap import dedent
 
@@ -36,6 +38,8 @@ WWW_DIR = APP_DIR / "www"
 CONFIG_DIR = Path("/etc/autopkgtest-website")
 SITES_AVAILABLE_PATH = Path("/etc/apache2/sites-available/")
 
+ALERTS_FILE = DATA_DIR / "alerts.json"
+
 # Packages to install
 PACKAGES = [
     "apache2",
@@ -54,14 +58,57 @@ PACKAGES = [
 ]
 
 
-def set_alert(level: str, message: str):
-    with open(DATA_DIR / "alert.txt", "w") as f:
-        f.write(f"{level.lower()}:{message}")
-    shutil.chown(DATA_DIR / "alert.txt", user=USER, group=USER)
+def _load_alerts() -> list:
+    """Load alerts from the alerts file."""
+    try:
+        with open(ALERTS_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
 
 
-def remove_alert():
-    (DATA_DIR / "alert.txt").unlink(missing_ok=True)
+def _save_alerts(alerts: list):
+    """Save alerts to the alerts file."""
+    with open(ALERTS_FILE, "w") as f:
+        json.dump(alerts, f, indent=2)
+    shutil.chown(ALERTS_FILE, user=USER, group=USER)
+
+
+def _get_next_alert_id() -> int:
+    """Get the next available alert ID."""
+    alerts = _load_alerts()
+    if not alerts:
+        return 1
+    return max(alert["id"] for alert in alerts) + 1
+
+
+def add_alert(level: str, message: str) -> int:
+    """Add an alert to be displayed on the website."""
+    alerts = _load_alerts()
+    alert_id = _get_next_alert_id()
+
+    new_alert = {
+        "id": alert_id,
+        "level": level.lower(),
+        "message": message,
+        "date": date.today().isoformat(),
+    }
+
+    alerts.append(new_alert)
+    _save_alerts(alerts)
+    return alert_id
+
+
+def remove_alert(alert_id: int):
+    """Remove an alert by its ID."""
+    alerts = _load_alerts()
+    alerts = [a for a in alerts if a["id"] != alert_id]
+    _save_alerts(alerts)
+
+
+def clear_alerts():
+    """Remove all alerts."""
+    ALERTS_FILE.unlink(missing_ok=True)
 
 
 def install() -> None:

--- a/charms/autopkgtest-website-operator/src/charm.py
+++ b/charms/autopkgtest-website-operator/src/charm.py
@@ -43,8 +43,15 @@ class AutopkgtestWebsiteCharm(ops.CharmBase):
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.upgrade_charm, self._on_install)
         framework.observe(self.on.start, self._on_start)
+
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.secret_changed, self._on_secret_changed)
+
+        framework.observe(self.on.add_alert_action, self._on_add_alert)
+        framework.observe(self.on.remove_alert_action, self._on_remove_alert)
+        framework.observe(self.on.clear_alerts_action, self._on_clear_alerts)
+        framework.observe(self.on.list_alerts_action, self._on_list_alerts)
+
         framework.observe(self.on.amqp_relation_joined, self._on_amqp_relation_joined)
         framework.observe(self.on.amqp_relation_changed, self._on_amqp_relation_changed)
         framework.observe(self.on.amqp_relation_broken, self._on_amqp_relation_broken)
@@ -117,12 +124,24 @@ class AutopkgtestWebsiteCharm(ops.CharmBase):
         self.unit.open_port("tcp", HTTP_PORT)
         self.unit.status = ops.ActiveStatus()
 
-    def _on_set_alert(self, event: ops.ActionEvent):
-        params = event.load_params(action_types.SetAlertAction, errors="fail")
-        autopkgtest_website.set_alert(params.level, params.message)
+    def _on_add_alert(self, event: ops.ActionEvent):
+        params = event.load_params(action_types.AddAlertAction, errors="fail")
+        alert_id = autopkgtest_website.add_alert(params.level.value, params.message)
+        event.set_results({"message": f"Alert set with ID {alert_id}"})
 
     def _on_remove_alert(self, event: ops.ActionEvent):
-        autopkgtest_website.remove_alert()
+        params = event.load_params(action_types.RemoveAlertAction, errors="fail")
+        alert_id = params.alert_id
+        autopkgtest_website.remove_alert(alert_id)
+        event.set_results({"message": f"Alert with ID {alert_id} removed"})
+
+    def _on_clear_alerts(self, event: ops.ActionEvent):
+        autopkgtest_website.clear_alerts()
+        event.set_results({"message": "All alerts cleared"})
+
+    def _on_list_alerts(self, event: ops.ActionEvent):
+        alerts = autopkgtest_website._load_alerts()
+        event.set_results({"alerts": alerts})
 
     def _on_amqp_relation_joined(self, event: ops.RelationJoinedEvent):
         self.unit.status = ops.MaintenanceStatus(


### PR DESCRIPTION
Significantly expand the alerts feature:
 - Allow setting multiple alerts at once.
 - Change remove-alert to take an index of which alert to remove.
 - Add new actions clear-all-alerts and list-alerts.
 - Change alerts file format to JSON.
 - Add datestamps to alerts.