### PR TITLE
dispatcher, janitor: fix initial call to update_status

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/src/charm.py
+++ b/charms/autopkgtest-dispatcher-operator/src/charm.py
@@ -70,6 +70,7 @@ class AutopkgtestDispatcherCharm(ops.CharmBase):
             return
 
         autopkgtest_dispatcher.start()
+        self.unit.status = ops.ActiveStatus()
         self.on.update_status.emit()
 
     def _on_update_status(self, event: ops.UpdateStatusEvent):

--- a/charms/autopkgtest-janitor-operator/src/charm.py
+++ b/charms/autopkgtest-janitor-operator/src/charm.py
@@ -62,6 +62,7 @@ class AutopkgtestJanitorCharm(ops.CharmBase):
             return
 
         autopkgtest_janitor.start()
+        self.unit.status = ops.ActiveStatus()
         self.on.update_status.emit()
 
     def _on_update_status(self, event: ops.UpdateStatusEvent):


### PR DESCRIPTION
Set the unit status to active before calling update_status for the first time.