### PR TITLE
website: add queue parsing

### DIFF
--- a/charms/autopkgtest-website-operator/app/www/browse.cgi
+++ b/charms/autopkgtest-website-operator/app/www/browse.cgi
@@ -165,8 +165,7 @@ def should_show_retry(code):
 def get_queues_info():
     """Return information about queued tests.
 
-    Return (releases, arches, context -> release -> arch -> (queue_size, [parsed_requests])).
-    Each parsed request is a dict with keys: package, requester, submit-time, triggers
+    Return (releases, arches, context -> release -> arch -> (queue_size, [requests])).
     """
     with open(CONFIG["amqp_queue_cache"]) as json_file:
         queue_info_j = json.load(json_file)
@@ -181,23 +180,9 @@ def get_queues_info():
                 for arch in queues[context][release]:
                     requests = queues[context][release][arch]["requests"]
                     size = queues[context][release][arch]["size"]
-
-                    parsed_requests = []
-                    for req in requests:
-                        try:
-                            parts = req.split("\n", 1)
-                            if len(parts) == 2:
-                                package = parts[0]
-                                req_json = json.loads(parts[1])
-                                req_json["package"] = package
-                                parsed_requests.append(req_json)
-                        except (json.JSONDecodeError, IndexError, ValueError):
-                            # skip malformed requests (like private jobs)
-                            continue
-
                     ctx.setdefault(context, {}).setdefault(release, {})[arch] = (
                         size,
-                        parsed_requests,
+                        requests,
                     )
 
         return (CONFIG["releases"], arches, ctx)
@@ -321,9 +306,14 @@ def get_queued_for_user(user: str):
                     continue
                 requests = queue_items[1]
                 for req in requests:
-                    if req.get("requester", "") == user:
-                        package = req.get("package", "")
-                        triggers = req.get("triggers", [])
+                    try:
+                        req_info = json.loads(req.split("\n")[1])
+                    except (json.JSONDecodeError, IndexError):
+                        # These usually result from `private job` instances
+                        continue
+                    package = req.split("\n")[0]
+                    if req_info.get("requester", "") == user:
+                        triggers = list(req_info.get("triggers", ""))
                         if isinstance(triggers, list):
                             triggers = " ".join(triggers)
                         queued_tests.append(
@@ -331,7 +321,7 @@ def get_queued_for_user(user: str):
                                 version="N/A",
                                 triggers=triggers,
                                 additional_params="N/A",
-                                human_date=human_date(req.get("submit-time")),
+                                human_date=human_date(req_info.get("submit-time")),
                                 human_sec="N/A",
                                 requester=user,
                                 code="queued",
@@ -450,7 +440,7 @@ def package_overview(package, _=None):
                     filtered_requests = [
                         r
                         for r in queue[release][arch][1]
-                        if r.get("package") == package
+                        if r.startswith(package + "\n")
                     ]
                     queues_info[queue_name][release][arch] = (
                         len(filtered_requests),  # update the size too
@@ -839,18 +829,19 @@ def package_release_arch(package, release, arch, _=None):
         for _, queue in queues_info.items():
             queue_items = queue.get(release, {}).get(arch, [0, []])[1]
             for item in queue_items:
-                if item.get("package") == package:
+                if item.startswith(package + "\n"):
+                    item_info = json.loads(item.split("\n")[1])
                     results.insert(
                         0,
                         dict(
                             version="N/A",
-                            triggers=item.get("triggers"),
+                            triggers=item_info.get("triggers"),
                             additional_params=(
                                 "all-proposed=1"
-                                if "all-proposed" in item.keys()
+                                if "all-proposed" in item_info.keys()
                                 else ""
                             ),
-                            human_date=human_date(item.get("submit-time")),
+                            human_date=human_date(item_info.get("submit-time")),
                             human_sec="N/A",
                             requester="-",
                             code="queued",

--- a/charms/autopkgtest-website-operator/app/www/browse.cgi
+++ b/charms/autopkgtest-website-operator/app/www/browse.cgi
@@ -188,6 +188,34 @@ def get_queues_info():
         return (CONFIG["releases"], arches, ctx)
 
 
+def parse_queues(queues):
+    """Parse the queues into dicts for use in templates."""
+    for queue, queue_info in queues.items():
+        for release, release_info in queue_info.items():
+            for arch, (size, requests) in release_info.items():
+                parsed_requests = []
+                for req in requests:
+                    try:
+                        parts = req.split("\n", 1)
+                        if len(parts) == 2:
+                            package = parts[0]
+                            req_json = json.loads(parts[1])
+                            req_json["package"] = package
+                            req_json["triggers"] = " ".join(
+                                req_json.get("triggers", [])
+                            )
+                            req_json["requester"] = req_json.get("requester", "-")
+                            # all requests *should* have a timestamp, but just in case
+                            req_json["submit-time"] = req_json.get("submit-time", "-")
+                            parsed_requests.append(req_json)
+                    except json.JSONDecodeError:
+                        # skip malformed or private requests
+                        continue
+                queues[queue][release][arch] = (size, parsed_requests)
+
+    return queues
+
+
 def db_has_result_requester_idx(cursor: sqlite3.Cursor):
     for row in cursor.execute("PRAGMA index_list('result')"):
         if row["name"] == "result_requester_idx":
@@ -299,36 +327,28 @@ def get_results(limit: int, offset: int = 0, **kwargs) -> list:
 def get_queued_for_user(user: str):
     queued_tests = []
     (_, _, queues_info) = get_queues_info()
+    queues_info = parse_queues(queues_info)
     for _, queue in queues_info.items():
         for release, queue_by_arch in queue.items():
             for arch, queue_items in queue_by_arch.items():
-                if queue_items[0] == 0:
+                if queue_items[0] == 0:  # queue is empty
                     continue
                 requests = queue_items[1]
                 for req in requests:
-                    try:
-                        req_info = json.loads(req.split("\n")[1])
-                    except (json.JSONDecodeError, IndexError):
-                        # These usually result from `private job` instances
-                        continue
-                    package = req.split("\n")[0]
-                    if req_info.get("requester", "") == user:
-                        triggers = list(req_info.get("triggers", ""))
-                        if isinstance(triggers, list):
-                            triggers = " ".join(triggers)
+                    if req.get("requester", "") == user:
                         queued_tests.append(
                             dict(
                                 version="N/A",
-                                triggers=triggers,
+                                triggers=req.get("triggers"),
                                 additional_params="N/A",
-                                human_date=human_date(req_info.get("submit-time")),
+                                human_date=human_date(req.get("submit-time")),
                                 human_sec="N/A",
                                 requester=user,
                                 code="queued",
                                 url="",
                                 show_retry=False,
                                 all_proposed="",
-                                package=package,
+                                package=req.get("package"),
                                 release=release,
                                 arch=arch,
                             ),
@@ -446,6 +466,8 @@ def package_overview(package, _=None):
                         len(filtered_requests),  # update the size too
                         filtered_requests,
                     )
+        # parse queues after filtering
+        queues_info = parse_queues(queues_info)
     except Exception:
         # We never want to fail in that block, even is there are issues with cache-amqp
         queues_info = {
@@ -826,22 +848,22 @@ def package_release_arch(package, release, arch, _=None):
     # Add queued jobs if any
     try:
         (_, _, queues_info) = get_queues_info()
+        queues_info = parse_queues(queues_info)
         for _, queue in queues_info.items():
             queue_items = queue.get(release, {}).get(arch, [0, []])[1]
             for item in queue_items:
-                if item.startswith(package + "\n"):
-                    item_info = json.loads(item.split("\n")[1])
+                if item["package"] == package:
                     results.insert(
                         0,
                         dict(
                             version="N/A",
-                            triggers=item_info.get("triggers"),
+                            triggers=item.get("triggers"),
                             additional_params=(
                                 "all-proposed=1"
-                                if "all-proposed" in item_info.keys()
+                                if "all-proposed" in item.keys()
                                 else ""
                             ),
-                            human_date=human_date(item_info.get("submit-time")),
+                            human_date=human_date(item.get("submit-time")),
                             human_sec="N/A",
                             requester="-",
                             code="queued",
@@ -1031,6 +1053,7 @@ def display_run_logs(release, arch, package, run_id):
 @app.route("/running")
 def running():
     (releases, arches, queues_info) = get_queues_info()
+    queues_info = parse_queues(queues_info)
     queues_lengths = {}
     for c in queues_info:
         for r in releases:

--- a/charms/autopkgtest-website-operator/app/www/templates/browse-user.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/browse-user.html
@@ -43,7 +43,9 @@
         {% set release = row["release"] %}
         {% set arch = row["arch"] %}
         {% set run_id = row.get("run_id", "") %}
-        <td>{{ package }}</td>
+        <td>
+          <a href="{{ url_for('package_overview', package=package) }}">{{ package }}</a>
+        </td>
         <td>{{ release }}</td>
         <td>{{ arch }}</td>
         {{ macros.results_table_core(row["version"], row["triggers"], row["additional_params"], row["human_date"], row["human_sec"], row["requester"], row["code"], row["url"], row["show_retry"], row["all_proposed"], run_id, package, release, arch) }}
@@ -77,11 +79,11 @@
     {% for row in tests %}
       <tr>
         {% set package = row["package"] %}
-        {% set release = row["release"] %}
-        {% set arch = row["arch"] %}
-        <td>{{ package }}</td>
-        <td>{{ release }}</td>
-        <td>{{ arch }}</td>
+        <td>
+          <a href="{{ url_for('package_overview', package=package) }}">{{ package }}</a>
+        </td>
+        <td>{{ row["release"] }}</td>
+        <td>{{ row["arch"] }}</td>
         <td>{{ row["triggers"] }}</td>
         <td>{{ row["additional_params"] }}</td>
         <td>{{ row["human_date"] }}</td>

--- a/charms/autopkgtest-website-operator/app/www/templates/macros.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/macros.html
@@ -107,30 +107,15 @@
                    id="queue-{{ queue_name }}-{{ r }}-{{ a }}">
               <thead>
                 <tr>
-                  <th colspan="4" class="sticky-table-headers">
-                    <h3 style="margin: 0;">Queued tests for {{ queue_name }} {{ r }} {{ a }}</h3>
+                  <th class="sticky-table-headers">
+                    <h3>Queued tests for {{ queue_name }} {{ r }} {{ a }}</h3>
                   </th>
-                </tr>
-                <tr>
-                  <th>Package</th>
-                  <th>Triggers</th>
-                  <th>Submit Time</th>
-                  <th>Requester</th>
                 </tr>
               </thead>
               <tbody>
                 {% for req in reqs %}
                   <tr>
-                    <td>{{ req.package }}</td>
-                    <td>{{ req.get('triggers', []) | join(", ") }}</td>
-                    <td>{{ req.get('submit-time', '-') }}</td>
-                    <td>
-                      {% if req.get("requester") %}
-                        <a href="https://launchpad.net/~{{ req.requester }}">{{ req.requester }}</a>
-                      {% else %}
-                        -
-                      {% endif %}
-                    </td>
+                    <td>{{ req }}</td>
                   </tr>
                 {% endfor %}
               </tbody>

--- a/charms/autopkgtest-website-operator/app/www/templates/macros.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/macros.html
@@ -107,15 +107,32 @@
                    id="queue-{{ queue_name }}-{{ r }}-{{ a }}">
               <thead>
                 <tr>
-                  <th class="sticky-table-headers">
+                  <th colspan="4" class="sticky-table-headers">
                     <h3>Queued tests for {{ queue_name }} {{ r }} {{ a }}</h3>
                   </th>
+                </tr>
+                <tr>
+                  <th>Package</th>
+                  <th>Triggers</th>
+                  <th>Submit Time</th>
+                  <th>Requester</th>
                 </tr>
               </thead>
               <tbody>
                 {% for req in reqs %}
                   <tr>
-                    <td>{{ req }}</td>
+                    <td>
+                      <a href="{{ url_for('package_overview', package=req.package) }}">{{ req.package }}</a>
+                    </td>
+                    <td>{{ req.triggers }}</td>
+                    <td>{{ req.submit_time }}</td>
+                    <td>
+                      {% if req.requester %}
+                        <a href="https://launchpad.net/~{{ req.requester }}">{{ req.requester }}</a>
+                      {% else %}
+                        -
+                      {% endif %}
+                    </td>
                   </tr>
                 {% endfor %}
               </tbody>


### PR DESCRIPTION
Instead of changing how queue info is gathered everywhere, add an optional `parse_queues` function that doesn't effect the external-facing `queues.json` file.