### PR TITLE
janitor: don't build bionic VM images using minimal images

### DIFF
--- a/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
+++ b/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
@@ -40,7 +40,10 @@ then
 fi
 
 # If there is a minimal images for the selected base release, prefer that.
-if "$@" "$minimgremote:$base/$arch" >/dev/null 2>&1; then
+# Some known bad base/type combinations are excluded.
+if { [ "$base" != bionic ] || [ "$type" != "vm" ]; } &&
+   "$@" "$minimgremote:$base/$arch" >/dev/null 2>&1
+then
     imgremote=$minimgremote
 fi
 


### PR DESCRIPTION
The kernel in minimal images lacks the vsock module, which makes the lxd-agent unusable.