### PR TITLE
janitor: do not use minimal images are a base for autopkgtest images

### DIFF
--- a/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
+++ b/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
@@ -11,7 +11,6 @@ export RELEASE
 
 remote="remote-$arch-$index"
 imgremote="ubuntu-daily"
-minimgremote="ubuntu-minimal-daily"
 base=$RELEASE
 
 if [ -z "${MIRROR-}" ]; then
@@ -37,14 +36,6 @@ if
 then
     echo "No $base image appears to be available, falling back to $stable"
     base=$stable
-fi
-
-# If there is a minimal images for the selected base release, prefer that.
-# Some known bad base/type combinations are excluded.
-if { [ "$base" != bionic ] || [ "$type" != "vm" ]; } &&
-   "$@" "$minimgremote:$base/$arch" >/dev/null 2>&1
-then
-    imgremote=$minimgremote
 fi
 
 # Construct the autopkgtest-build-lxd command line in $@.


### PR DESCRIPTION
Minimal images come with a restricted set of packages (good), but also with dpkg excludes (`/etc/dpkg/dpkg.cfg.d/excludes`, see `--path-exclude` in the dpkg(1) manpage); those excludes prevent installation of:
```
path-exclude=/usr/share/man/*
path-exclude=/usr/share/locale/*/LC_MESSAGES/*.mo
path-exclude=/usr/share/doc/*
path-include=/usr/share/doc/*/copyright
path-include=/usr/share/doc/*/changelog.*
```
This breaks test expectations, and also deviate from what users normally will get on their systems. We could "unminimize" a minimal images, following part of what the `unminimize` script installing on such images does, but this defeats much of of the advantage of using minimal images in the first place.