### PR TITLE
workflows: add cd pipelines

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -1,0 +1,92 @@
+name: publish-edge
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_all:
+        description: Build & publish all charms regardless of changed paths
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      charms: ${{ steps.matrix.outputs.charms }}
+      any: ${{ steps.matrix.outputs.any }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        with:
+          filters: |
+            dispatcher:
+              - 'charms/autopkgtest-dispatcher-operator/**'
+            janitor:
+              - 'charms/autopkgtest-janitor-operator/**'
+            website:
+              - 'charms/autopkgtest-website-operator/**'
+
+      - id: matrix
+        env:
+          FORCE_ALL: ${{ inputs.force_all }}
+          CHANGED_DISPATCHER: ${{ steps.filter.outputs.dispatcher }}
+          CHANGED_JANITOR: ${{ steps.filter.outputs.janitor }}
+          CHANGED_WEBSITE: ${{ steps.filter.outputs.website }}
+        run: |
+          CHARMS='[]'
+
+          add_if_changed() {
+            local name="$1"
+            local path="$2"
+            local changed="$3"
+            if [[ "$FORCE_ALL" == 'true' || "$changed" == 'true' ]]; then
+              CHARMS=$(printf '%s' "$CHARMS" | jq --arg name "$name" --arg path "$path" \
+                '. + [{"name": $name, "path": $path}]')
+            fi
+          }
+
+          add_if_changed dispatcher charms/autopkgtest-dispatcher-operator "$CHANGED_DISPATCHER"
+          add_if_changed janitor    charms/autopkgtest-janitor-operator    "$CHANGED_JANITOR"
+          add_if_changed website    charms/autopkgtest-website-operator    "$CHANGED_WEBSITE"
+
+          echo "charms=$CHARMS" >> "$GITHUB_OUTPUT"
+          if [[ "$CHARMS" == '[]' ]]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        charm: ${{ fromJSON(needs.detect-changes.outputs.charms) }}
+    name: publish ${{ matrix.charm.name }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: canonical/charming-actions/upload-charm@1753e0803f70445132e92acd45c905aba6473225  # 2.7.0
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          charm-path: ${{ matrix.charm.path }}
+          channel: latest/edge
+          upload-image: 'false'
+          github-tag: 'false'

--- a/.github/workflows/publish-stable.yaml
+++ b/.github/workflows/publish-stable.yaml
@@ -1,0 +1,76 @@
+name: publish-stable
+
+on:
+  push:
+    tags:
+      - 'dispatcher-*'
+      - 'janitor-*'
+      - 'website-*'
+  workflow_dispatch:
+    inputs:
+      charm:
+        description: Charm short name
+        type: choice
+        required: true
+        options: [dispatcher, janitor, website]
+      revision:
+        description: Charmhub revision number
+        type: string
+        required: true
+      channel:
+        description: Destination channel (e.g. latest/stable, latest/candidate)
+        type: string
+        required: true
+        default: latest/stable
+
+permissions: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse and validate parameters
+        id: params
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.ref_name }}
+          IN_CHARM: ${{ inputs.charm }}
+          IN_REVISION: ${{ inputs.revision }}
+          IN_CHANNEL: ${{ inputs.channel }}
+        run: |
+          if [[ "$EVENT" == 'workflow_dispatch' ]]; then
+            charm="$IN_CHARM"
+            revision="$IN_REVISION"
+            channel="$IN_CHANNEL"
+          else
+            charm="${TAG%-*}"
+            revision="${TAG##*-}"
+            channel="latest/stable"
+          fi
+
+          [[ "$revision" =~ ^[1-9][0-9]*$ ]] \
+            || { echo "::error::invalid revision '${revision}' — must be a positive integer"; exit 1; }
+
+          case "$charm" in
+            dispatcher) full_name="ubuntu-autopkgtest-dispatcher" ;;
+            janitor)    full_name="ubuntu-autopkgtest-janitor" ;;
+            website)    full_name="ubuntu-autopkgtest-website" ;;
+            *)          echo "::error::unknown charm '${charm}' — expected dispatcher, janitor, or website"; exit 1 ;;
+          esac
+
+          {
+            echo "charm=$full_name"
+            echo "revision=$revision"
+            echo "channel=$channel"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Release ${{ steps.params.outputs.charm }} rev ${{ steps.params.outputs.revision }} to ${{ steps.params.outputs.channel }}
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
+          CHARM: ${{ steps.params.outputs.charm }}
+          REVISION: ${{ steps.params.outputs.revision }}
+          CHANNEL: ${{ steps.params.outputs.channel }}
+        run: charmcraft release "$CHARM" --revision="$REVISION" --channel="$CHANNEL"


### PR DESCRIPTION
Add two new workflows: publish-edge and publish-stable. The former runs on every push to main and publishes a new revision of whichever charm(s) were changes to charmhub. The latter runs on every tag in the format `<charm_name>-<charm_revision>` and promotes the revision of the desired charm(s) to the selected channel (stable by default).