### PR TITLE
dispatcher: add safeguards to set-worker-count action

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
+++ b/charms/autopkgtest-dispatcher-operator/charmcraft.yaml
@@ -57,6 +57,10 @@ actions:
         type: string
         description: Architecture to set units for.
         enum: [amd64, amd64v3, i386, arm64, armhf, s390x, ppc64el, riscv64]
+      index:
+        type: integer
+        description: Index of the remote to set worker count for.
+        min: 1
       count:
         type: integer
         description: Number of workers.

--- a/charms/autopkgtest-dispatcher-operator/src/action_types.py
+++ b/charms/autopkgtest-dispatcher-operator/src/action_types.py
@@ -30,4 +30,4 @@ class RemoveRemoteAction(pydantic.BaseModel):
 class SetWorkerCountAction(pydantic.BaseModel):
     arch: SupportedArches = pydantic.Field(description="Architecture to configure.")
     index: int = pydantic.Field(description="Index of the remote to configure.")
-    count: int = pydantic.Field(10)
+    count: int = pydantic.Field(3, description="Number of workers.")

--- a/charms/autopkgtest-dispatcher-operator/src/charm.py
+++ b/charms/autopkgtest-dispatcher-operator/src/charm.py
@@ -131,6 +131,10 @@ class AutopkgtestDispatcherCharm(ops.CharmBase):
         index = params.index
         remote_key = self._get_remote_key(arch, index)
 
+        if remote_key not in self._stored.workers:
+            event.fail(f"remote with index {index} does not exist for {arch}")
+            return
+
         event.log(f"Setting worker count for arch {remote_key}")
         self._stored.workers[remote_key] = params.count
         event.set_results(


### PR DESCRIPTION
Made sure we are not able to set worker count for a remote that does not exist, which left bad entries in the workers dict.

Also updated charmcraft to include the index parameter, which was previously only implied by action_types.