### PR TITLE
dispatcher: worker config: stop injecting http proxy variables

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -576,7 +576,6 @@ def request(channel, method, properties, body):
         else:
             argv = ["autopkgtest"]
         argv += ["--output-dir", out_dir]
-        argv += ["--needs-internet=try"]
 
         if i386_foreign_series(release) and architecture == "i386":
             argv += ["-a", "i386"]

--- a/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
+++ b/charms/autopkgtest-dispatcher-operator/src/autopkgtest_dispatcher.py
@@ -80,12 +80,6 @@ def is_proxy_defined():
 
 def write_worker_config(releases):
     extra_args = []
-    if is_proxy_defined():
-        extra_args = [
-            f"--env http_proxy={os.getenv('JUJU_CHARM_HTTP_PROXY')}",
-            f"--env https_proxy={os.getenv('JUJU_CHARM_HTTPS_PROXY')}",
-            f"--env no_proxy={os.getenv('JUJU_CHARM_NO_PROXY')}",
-        ]
     with open(WORKER_CONFIG_PATH, "w") as file:
         file.write(
             dedent(


### PR DESCRIPTION
Superseded by https://github.com/canonical/ubuntu-engineering-terraform-models/pull/592/.