### PR TITLE
cd: publish-edge: fix workflow

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - id: filter
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         with:
           filters: |
             dispatcher:
@@ -50,7 +50,7 @@ jobs:
             local path="$2"
             local changed="$3"
             if [[ "$FORCE_ALL" == 'true' || "$changed" == 'true' ]]; then
-              CHARMS=$(printf '%s' "$CHARMS" | jq --arg name "$name" --arg path "$path" \
+              CHARMS=$(printf '%s' "$CHARMS" | jq -c --arg name "$name" --arg path "$path" \
                 '. + [{"name": $name, "path": $path}]')
             fi
           }


### PR DESCRIPTION
Pinned the version of paths-filter to one that uses a current version of node and fixed the invocation of jq.