### PR TITLE
janitor: turn autopkgtest-build-image into a Type=notify service

### DIFF
--- a/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
+++ b/charms/autopkgtest-janitor-operator/app/bin/build-image-on-remote
@@ -49,7 +49,17 @@ set -- "$@" --remote "$remote" "$imgremote:$base/$arch"
 # is started from the systemd service, then limit to one image build
 # per remote.
 if [ -d "${RUNTIME_DIRECTORY-}" ]; then
-    set -- flock --verbose "$RUNTIME_DIRECTORY/$remote.lock" "$@"
+    # Open the lock file on fd 9 and block until the per-remote lock is
+    # available. The fd is kept open across the final exec below, so the lock
+    # is held for the whole build.
+    exec 9>"$RUNTIME_DIRECTORY/$remote.lock"
+    flock --verbose 9
+
+    # Lock acquired: tell systemd the build is about to start, so the unit
+    # transitions to "running" and RuntimeMaxSec starts counting from here.
+    if [ -n "${NOTIFY_SOCKET-}" ]; then
+        systemd-notify --ready
+    fi
 fi
 
 exec "$@"

--- a/charms/autopkgtest-janitor-operator/app/units/autopkgtest-build-image@.service.j2
+++ b/charms/autopkgtest-janitor-operator/app/units/autopkgtest-build-image@.service.j2
@@ -4,9 +4,11 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=exec
+Type=notify
+NotifyAccess=all
 User={{ user }}
 TimeoutStartSec=18h
+RuntimeMaxSec=2h
 EnvironmentFile=-/etc/environment.d/proxy.conf
 Environment="PATH={{ autopkgtest_location }}/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin"
 Environment="MIRROR={{ mirror }}"


### PR DESCRIPTION
This fixes a bug: `TimeoutStartSec` did not meaningfully apply to the `Type=exec` service, as such services do not really have a "startup" phase.

Using a Type=notify allows to differentiate the "wait for lock to be releases phase", where the service will appear as "activating":

```
● autopkgtest-build-image@amd64-35-jammy-vm.service - Build autopkgtest testbed image (amd64-35-jammy-vm)
     Loaded: loaded (/etc/systemd/system/autopkgtest-build-image@.service; static)
     Active: activating (start) since Mon 2026-06-22 12:37:04 UTC; 24min ago
```

while in the actual image building phase the service will be "running":

```
● autopkgtest-build-image@amd64-35-jammy-container.service - Build autopkgtest testbed image (amd64-35-jammy-container)
     Loaded: loaded (/etc/systemd/system/autopkgtest-build-image@.service; static)
     Active: active (running) since Mon 2026-06-22 12:58:45 UTC; 2min 34s ago
```