### PR TITLE
dispatcher: worker: fix bogus version for arch-restricted requests

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -524,7 +524,7 @@ def request(channel, method, properties, body):
             with open(os.path.join(out_dir, "log"), "w") as log:
                 log.write(errormessage)
             with open(os.path.join(out_dir, "testpkg-version"), "w") as testpkg_version:
-                testpkg_version.write(errormessage)
+                testpkg_version.write(f"{pkgname} unknown")
             dont_run = True
         elif request_matches_per_package(pkgname, architecture, release, never_run):
             logging.warning("Marked to never run, ignoring")


### PR DESCRIPTION
The arch-release restriction branch wrote the free-form errormessage into testpkg-version, but `process_output_dir` parses the version as the second whitespace-separated token. This recorded a misleading version (e.g. "running" from "Only running amd64 tests ...").

Write `{pkgname} unknown` instead, as we do in the case of testbed failures. The human-readable message remains in the log file.