### PR TITLE
dispatcher: worker: force creation of s390x VMs with a single CPU

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -711,6 +711,10 @@ def request(channel, method, properties, body):
             architecture if architecture != "i386" else "amd64",
         ).split()
 
+        # workaround for https://github.com/canonical/lxd/issues/16752
+        if architecture == "s390x":
+            argv = [re.sub(r"^limits\.cpu=\d+$", "limits.cpu=1", a) for a in argv]
+
         if "swiftuser" in params:
             private = True
         elif private:


### PR DESCRIPTION
Workaround for https://github.com/canonical/lxd/issues/16752.