### PR TITLE
website: macros: get queue properties with dict-style accessors

### DIFF
--- a/charms/autopkgtest-website-operator/app/www/templates/macros.html
+++ b/charms/autopkgtest-website-operator/app/www/templates/macros.html
@@ -128,11 +128,11 @@
                 {% for req in reqs %}
                   <tr>
                     <td>
-                      <a href="{{ url_for('package_overview', package=req.package) }}">{{ req.package }}</a>
+                      <a href="{{ url_for('package_overview', package=req["package"]) }}">{{ req["package"] }}</a>
                     </td>
-                    <td>{{ req.triggers }}</td>
-                    <td>{{ req.submit_time }}</td>
-                    <td>{{ render_requester(req.requester) }}</td>
+                    <td>{{ req["triggers"] }}</td>
+                    <td>{{ req["submit-time"] }}</td>
+                    <td>{{ render_requester(req["requester"]) }}</td>
                   </tr>
                 {% endfor %}
               </tbody>


### PR DESCRIPTION
The submit-time field uses a hyphen instead of an underscore which is an illegal accessor in python/jinja. Switch to using dict-style accessors everywhere so we can use the hyphen in submit-time and all accesses remain consistent.