### PR TITLE
website: block Apple user-agents

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
@@ -10,7 +10,7 @@
   RewriteRule ^/favicon\.ico$ - [R=204,L]
 
   # Block AI crawlers
-  RewriteCond %{HTTP_USER_AGENT} ".*(Macintosh|Windows).*" [NC]
+  RewriteCond %{HTTP_USER_AGENT} ".*(Macintosh|Windows|Apple).*" [NC]
   RewriteRule ^ - [F,L]
 
   RemoteIPHeader X-Forwarded-For


### PR DESCRIPTION
Meant to block scrapers like:
```
10.151.110.14 - - [30/Jun/2026:14:38:48 +0000] "GET /packages/libsoup3/noble/s390x/20240811_024745_acff2@ HTTP/1.1" 403 448 "https://autopkgtest.ubuntu.com/packages/libs/libsoup3/noble/s390x" "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.4; +https://openai.com/gptbot)"
```
This is meant to be temporary, to be replaced by something that can selectively block scrapers without requiring Javascript.