### PR TITLE
website: block GPTBot instead of Apple

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
@@ -10,7 +10,7 @@
   RewriteRule ^/favicon\.ico$ - [R=204,L]
 
   # Block AI crawlers
-  RewriteCond %{HTTP_USER_AGENT} ".*(Macintosh|Windows|Apple).*" [NC]
+  RewriteCond %{HTTP_USER_AGENT} ".*(Macintosh|Windows|GPTBot).*" [NC]
   RewriteRule ^ - [F,L]
 
   RemoteIPHeader X-Forwarded-For


### PR DESCRIPTION
Turns out that blocking Apple, as done in [1], is too wide, as it blocks `AppleWebKit` user-agents, which includes Chrome. Let's try blocking `GPTBot` instead.

As mentioned in [1], this is not a very good approach, as is to be considered temporary.

[1] https://github.com/canonical/ubuntu-autopkgtest-operators/pull/125