### PR TITLE
dispatcher: worker: add i386 to support matrix

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -53,11 +53,11 @@ ARCH_RELEASE_RESTRICTION_MAPPING = {
     "trusty": ["amd64"],
     "xenial": ["amd64", "s390x"],
     "bionic": ["amd64", "arm64", "ppc64el", "s390x"],
-    "focal": ["amd64", "arm64", "armhf", "ppc64el", "s390x"],
-    "jammy": ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"],
-    "noble": ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"],
-    "oracular": ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"],
-    "questing": ["amd64", "arm64", "armhf", "ppc64el", "riscv64", "s390x"],
+    "focal": ["amd64", "arm64", "armhf", "i386", "ppc64el", "s390x"],
+    "jammy": ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"],
+    "noble": ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"],
+    "oracular": ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"],
+    "questing": ["amd64", "arm64", "armhf", "i386", "ppc64el", "riscv64", "s390x"],
 }
 
 # Architectures supporting VM testbeds.


### PR DESCRIPTION
Add i386 for all releases where it is a partial architecture. We do not run or plan of running testbeds where i386 is the native dpkg arch, but testing as a foreign architecture is supported.