### PR TITLE
website: allow Ubuntu user agents as not-crawler

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
@@ -12,7 +12,7 @@
   # Block naive AI crawlers: require a cookie that only a real browser
   # (executing JavaScript) will set. Allow known CLI tooling through.
   ErrorDocument 429 "<script>document.cookie='not_a_crawler=1; path=/';location.reload();</script>"
-  RewriteCond %{HTTP_USER_AGENT} !^(curl|Wget|Python-urllib) [NC]
+  RewriteCond %{HTTP_USER_AGENT} !^(curl|Wget|Python-urllib|ubuntu/) [NC]
   RewriteCond %{HTTP_COOKIE} !not_a_crawler=1 [NC]
   RewriteRule ^ - [R=429,L]
 


### PR DESCRIPTION
Proposing the solution suggested in ticket ISREQ-3988 to allow named agents but identify them via a namespace