### PR TITLE
website: stop redirecting to ps5 for old logs

### DIFF
--- a/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
+++ b/charms/autopkgtest-website-operator/app/conf/a2-autopkgtest.conf.j2
@@ -33,7 +33,6 @@
   SetEnv HTTPS_PROXY "{{ https_proxy }}"
   {%- if swift_storage_url.startswith('https://') %}
   ProxyRemote "{{ swift_storage_url }}" "{{ https_proxy }}"
-  ProxyRemote "https://objectstorage.prodstack5.canonical.com/swift/v1/AUTH_0f9aae918d5b4744bf7b827671c86842/" "http://egress.ps7.internal:3128"
   {%- endif %}
   {%- endif %}
   {%- if http_proxy %}
@@ -56,7 +55,6 @@
   # reverse proxy rules
   SSLProxyEngine on
   {% if swift_storage_url %}
-  ProxyPassMatch "^/results/(autopkgtest-[a-z0-9-]+/[a-z]+/[a-z0-9]+/[a-z0-9]+/[a-z0-9.-]+/20(?:(?:[01][0-9]|2[0-5])[0-9]{4}|260[0-3][0-9]{2}|2604[01][0-9]|26042[0-8])_[0-9]+_[a-z0-9]+@/log.gz)" "https://objectstorage.prodstack5.canonical.com/swift/v1/AUTH_0f9aae918d5b4744bf7b827671c86842/$1"
   ProxyPass "/results/" "{{ swift_storage_url }}"
   {%- endif %}
   ProxyPass "/rabbitmq-management/" "http://{{ rabbithost }}:15672/"


### PR DESCRIPTION
All logs have been cloned to ps7, we can stop redirecting now.