### PR TITLE
dispatcher: worker: revert to ack-ing requests before processing

### DIFF
--- a/charms/autopkgtest-dispatcher-operator/app/bin/worker
+++ b/charms/autopkgtest-dispatcher-operator/app/bin/worker
@@ -735,6 +735,9 @@ def request(channel, method, properties, body):
         if private:
             container = f"private-{container}"
 
+        logging.info(f"Acknowledging request {body}")
+        channel.basic_ack(delivery_tag=method.delivery_tag)
+
         # run autopkgtest
         if not dont_run:
             global running_test
@@ -929,9 +932,6 @@ def request(channel, method, properties, body):
         ),
     )
     complete_amqp.close()
-
-    logging.info(f"Acknowledging request {body}")
-    channel.basic_ack(delivery_tag=method.delivery_tag)
 
     running_test = False
 


### PR DESCRIPTION
Sending an ack after processing finished was more resilient for some failure modes but caused the AMQP connection to time out for long running tests, which caused the worker to die and the test to return to the queue.

This reverts commit 63886da23f07ce4099872eec41d4aaac2fadf8e3.